### PR TITLE
Exclude blob_properties for filestorage, support azure_files_authenticatino

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,16 +50,20 @@ resource "azurerm_storage_account" "account" {
     }
   }
 
-  blob_properties {
-    delete_retention_policy {
-      days = var.account_kind == "FileStorage" ? null : var.blob_soft_delete_retention_days
+  dynamic "blob_properties" {
+    for_each = var.account_kind == "FileStorage" ? [] : ["blob_properties"]
+    content {
+      delete_retention_policy {
+        days = var.blob_soft_delete_retention_days
+      }
+
+      container_delete_retention_policy {
+        days = var.container_soft_delete_retention_days
+      }
+      versioning_enabled       = var.enable_versioning
+      last_access_time_enabled = var.enable_versioning
+      change_feed_enabled      = var.enable_versioning
     }
-    container_delete_retention_policy {
-      days = var.account_kind == "FileStorage" ? null : var.container_soft_delete_retention_days
-    }
-    versioning_enabled       = var.account_kind == "FileStorage" ? null : var.enable_versioning
-    last_access_time_enabled = var.account_kind == "FileStorage" ? null : var.last_access_time_enabled
-    change_feed_enabled      = var.account_kind == "FileStorage" ? null : var.change_feed_enabled
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -80,10 +80,10 @@ resource "azurerm_storage_account" "account" {
         content {
           domain_guid         = active_directory.value.domain_guid
           domain_name         = active_directory.value.domain_name
-          domain_sid          = active_directory.value.domain_sid
-          forest_name         = active_directory.value.forest_name
-          netbios_domain_name = active_directory.value.netbios_domain_name
-          storage_sid         = active_directory.value.storage_sid
+          domain_sid          = azure_files_authentication.value.directory_type == "AD" ? active_directory.value.domain_sid : null
+          forest_name         = azure_files_authentication.value.directory_type == "AD" ? active_directory.value.forest_name : null
+          netbios_domain_name = azure_files_authentication.value.directory_type == "AD" ? active_directory.value.netbios_domain_name : null
+          storage_sid         = azure_files_authentication.value.directory_type == "AD" ? active_directory.value.storage_sid : null
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -67,10 +67,25 @@ resource "azurerm_storage_account" "account" {
   }
 
   dynamic "azure_files_authentication" {
-    for_each = var.azure_domain_join_type != null ? [1] : []
-
+    for_each = var.azure_files_authentication == null ? [] : [
+      var.azure_files_authentication
+    ]
     content {
-      directory_type = var.azure_domain_join_type
+      directory_type = azure_files_authentication.value.directory_type
+
+      dynamic "active_directory" {
+        for_each = azure_files_authentication.value.active_directory == null ? [] : [
+          azure_files_authentication.value.active_directory
+        ]
+        content {
+          domain_guid         = active_directory.value.domain_guid
+          domain_name         = active_directory.value.domain_name
+          domain_sid          = active_directory.value.domain_sid
+          forest_name         = active_directory.value.forest_name
+          netbios_domain_name = active_directory.value.netbios_domain_name
+          storage_sid         = active_directory.value.storage_sid
+        }
+      }
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,14 @@ resource "azurerm_storage_account" "account" {
       change_feed_enabled      = var.enable_versioning
     }
   }
+
+  dynamic "azure_files_authentication" {
+    for_each = var.azure_domain_join_type != null ? [1] : []
+
+    content {
+      directory_type = var.azure_domain_join_type
+    }
+  }
 }
 
 resource "azurerm_advanced_threat_protection" "atp" {

--- a/variables.tf
+++ b/variables.tf
@@ -170,10 +170,10 @@ variable "azure_files_authentication" {
     active_directory = optional(object({
       domain_guid         = optional(string, null)
       domain_name         = optional(string, null)
-      domain_sid          = optional(string, null)
-      forest_name         = optional(string, null)
-      netbios_domain_name = optional(string, null)
-      storage_sid         = optional(string, null)
+      domain_sid          = optional(string, " ")
+      forest_name         = optional(string, " ")
+      netbios_domain_name = optional(string, " ")
+      storage_sid         = optional(string, " ")
     }))
   })
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -168,12 +168,12 @@ variable "azure_files_authentication" {
   type = object({
     directory_type = string
     active_directory = optional(object({
-      domain_guid         = string
-      domain_name         = string
-      domain_sid          = string
-      forest_name         = string
-      netbios_domain_name = string
-      storage_sid         = string
+      domain_guid         = optional(string, null)
+      domain_name         = optional(string, null)
+      domain_sid          = optional(string, null)
+      forest_name         = optional(string, null)
+      netbios_domain_name = optional(string, null)
+      storage_sid         = optional(string, null)
     }))
   })
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,9 @@ variable "https_only" {
   description = "Is HTTPS only enabled? Defaults to true. Must be false for using NFS protocol towards Azure Files."
   default     = true
 }
+
+variable "azure_domain_join_type" {
+  type        = string
+  description = "The type of domain join. Defaults to null. Supported: AADDS, AD and AADKERB"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -164,8 +164,29 @@ variable "https_only" {
   default     = true
 }
 
-variable "azure_domain_join_type" {
-  type        = string
-  description = "The type of domain join. Defaults to null. Supported: AADDS, AD and AADKERB"
+variable "azure_files_authentication" {
+  type = object({
+    directory_type = string
+    active_directory = optional(object({
+      domain_guid         = string
+      domain_name         = string
+      domain_sid          = string
+      forest_name         = string
+      netbios_domain_name = string
+      storage_sid         = string
+    }))
+  })
   default     = null
+  description = <<-EOT
+ - `directory_type` - (Required) Specifies the directory service used. Possible values are `AADDS`, `AD` and `AADKERB`.
+
+ ---
+ `active_directory` block supports the following:
+ - `domain_guid` - (Required) Specifies the domain GUID.
+ - `domain_name` - (Required) Specifies the primary domain that the AD DNS server is authoritative for.
+ - `domain_sid` - (Required) Specifies the security identifier (SID).
+ - `forest_name` - (Required) Specifies the Active Directory forest.
+ - `netbios_domain_name` - (Required) Specifies the NetBIOS domain name.
+ - `storage_sid` - (Required) Specifies the security identifier (SID) for Azure Storage.
+EOT
 }


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Resolve issues when creating storage accounts of type "FileStorage"
Add support for setting azure_files_authentication (can be used by hybrid joined VMs to use storage accounts)
```
