### PR TITLE
ignore changes to private_dns_zone_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,10 @@ resource "azurerm_private_endpoint" "pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name, name]
+    ignore_changes = [
+      private_service_connection[0].name, name,
+      private_dns_zone_group,
+    ]
   }
 }
 


### PR DESCRIPTION
Terraform need to ignore changes to this value to support policy that creates dns zone groups for private endpoints

## Changelog entry
```
ignore changes to private_dns_zone_group in private endpoint resources
```